### PR TITLE
Documentation build fails since changes in matplotlib's annotate function

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install apt packages
         run: sudo apt install pcsc-tools
       - name: Install pip packages
-        run: pip install flake8 pytest
+        run: pip install flake8 pytest crcmod
       - name: Lint Python
         run: find . -type f -name '*.py' -exec flake8 '{}' '+'
       - name: Test Python

--- a/api/setup.py
+++ b/api/setup.py
@@ -32,6 +32,6 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Ledger-Donjon/scaffold",
-    install_requires=["pyserial", "crcmod"],
+    install_requires=["pyserial", "crcmod", "requests"],
     packages=find_packages(),
     python_requires=">=3.6")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,9 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Use wavedrompy as alternative
+render_using_wavedrompy = True
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ release = '0.3'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -100,7 +100,7 @@ html_logo = 'logo.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/exts/modbox.py
+++ b/docs/exts/modbox.py
@@ -75,7 +75,7 @@ def make_fig(path, inputs, outputs):
             box_left - arrow_length_left, -i, arrow_length_left - hl, 0,
             fc='k', ec='k', head_length=hl, head_width=hw, lw=line_width)
         ax.annotate(
-            s=name, xy=(box_left + text_margin, -i),
+            text=name, xy=(box_left + text_margin, -i),
             horizontalalignment='left', verticalalignment='center')
 
     num_feedback = 0
@@ -85,7 +85,7 @@ def make_fig(path, inputs, outputs):
             box_right, -i, arrow_length_right - hl, 0, fc='k', ec='k',
             head_length=hl, head_width=hw, lw=line_width)
         ax.annotate(
-            s=name, xy=(box_right - text_margin, -i),
+            text=name, xy=(box_right - text_margin, -i),
             horizontalalignment='right', verticalalignment='center')
         if name in feedback_signals:
             x0 = box_right + num_feedback + 1


### PR DESCRIPTION
The matplotlib's `annotate` function has changed its parameter name from `s` to `text`.
This PR updates `modbox.py` file for this change.

Also, to remove warnings, in `conf.py` file:
- Language is set to "en" instead of "None"
- "_static" folder is removed from html_static_path