### PR TITLE
Fix SPI and I2C frequency computation

### DIFF
--- a/api/scaffold/__init__.py
+++ b/api/scaffold/__init__.py
@@ -1326,7 +1326,7 @@ class I2C(Module):
             raise ValueError("Target frequency is too low.")
         if d < 1:
             raise ValueError("Target frequency is too high.")
-        real = self.parent.sys_freq / (d + 1)
+        real = self.parent.sys_freq / (4 * (d + 1))
         self.reg_divisor.set(d)
         self.__cache_frequency = real
 
@@ -1428,13 +1428,13 @@ class SPI(Module):
 
     @frequency.setter
     def frequency(self, value: float):
-        d = round((self.parent.sys_freq / (4 * value)) - 1)
+        d = round((self.parent.sys_freq / (2 * value)) - 1)
         # Check that the divisor can be stored on 16 bits.
         if d > 0xFFFF:
             raise ValueError("Target frequency is too low.")
         if d < 1:
             raise ValueError("Target frequency is too high.")
-        real = self.parent.sys_freq / (d + 1)
+        real = self.parent.sys_freq / (2 * (d + 1))
         self.reg_divisor.set(d)
         self.__cache_frequency = real
 


### PR DESCRIPTION
- SPI: The frequency setter used a divisor factor of 4 (seems copy-pasted from I2C), but the SPI hardware only has 2 FSM states per SCK period (`st_transmit_a`, `st_transmit_b`). So for a frequency sets to 1MHz, the real frequency was actually 2 MHz. Also fixed the cached frequency computation.
- I2C: The cached frequency computation was also done incorrectly.

Should fix https://github.com/Ledger-Donjon/scaffold/issues/10